### PR TITLE
Deploy MX and SRV records with priority

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -8,3 +8,13 @@ records:
       type: CNAME
       ttl: 600
       content: pixie.porkbun.com
+    - type: MX
+      host: bacontest42.com
+      content: in1-smtp.messagingengine.com
+      ttl: 600
+      priority: 10
+    - type: MX
+      host: bacontest42.com
+      content: in2-smtp.messagingengine.com
+      ttl: 600
+      priority: 20

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,6 +16,11 @@ records:
       type: CNAME
       ttl: 600
       content: pixie.porkbun.com
+    - type: MX
+      host: bacontest42.com
+      content: in1-smtp.messagingengine.com
+      ttl: 600
+      priority: 10
 `)
 	if err != nil {
 		t.Fatal("could not seed config to temp file", err)
@@ -26,8 +31,8 @@ records:
 		t.Fatal("could not read config file", err)
 	}
 
-	if len(config.Records) != 2 {
-		t.Fatal("expected 2 records after deployment, got", len(config.Records))
+	if len(config.Records) != 3 {
+		t.Fatal("expected 3 records after deployment, got", len(config.Records))
 	}
 }
 
@@ -138,5 +143,25 @@ records:
 	_, err = ReadFile(configFile)
 	if err == nil {
 		t.Fatal("expected error when a record is missing content field", err)
+	}
+}
+
+func TestInvalidConfigInvalidPriority(t *testing.T) {
+	configFile, err := SeedConfigToTempFile(`
+domain: bacontest42.com
+records:
+    - host: bacontest42.com
+      type: ALIAS
+      ttl: 600
+      content: pixie.porkbun.com
+	  priority: 20
+`)
+	if err != nil {
+		t.Fatal("could not seed config to temp file", err)
+	}
+
+	_, err = ReadFile(configFile)
+	if err == nil {
+		t.Fatal("priority is not allowed on ALIAS records", err)
 	}
 }

--- a/pkg/config/record.go
+++ b/pkg/config/record.go
@@ -6,6 +6,13 @@ import (
 	"strings"
 )
 
+const (
+	// Record types that are allowed. Found in Porkbun's API documentation.
+	TYPE_ALLOWLIST = "A, MX, CNAME, ALIAS, TXT, NS, AAAA, SRV, TLSA, CAA, HTTPS, SVCB"
+	// Record types that are allowed to have a priority. Found in Porkbun's API documentation.
+	PRIORITY_ALLOWLIST = "MX, SRV"
+)
+
 type Record struct {
 	Name     string `yaml:"host"`
 	Type     string `yaml:"type"`
@@ -13,11 +20,6 @@ type Record struct {
 	Data     string `yaml:"content"`
 	Priority int    `yaml:"priority"`
 }
-
-const (
-	TYPE_ALLOWLIST     = "A, MX, CNAME, ALIAS, TXT, NS, AAAA, SRV, TLSA, CAA, HTTPS, SVCB"
-	PRIORITY_ALLOWLIST = "MX, SRV"
-)
 
 func (r Record) GetName() string {
 	return r.Name

--- a/pkg/config/record.go
+++ b/pkg/config/record.go
@@ -7,14 +7,16 @@ import (
 )
 
 type Record struct {
-	Name string `yaml:"host"`
-	Type string `yaml:"type"`
-	Ttl  int    `yaml:"ttl"`
-	Data string `yaml:"content"`
+	Name     string `yaml:"host"`
+	Type     string `yaml:"type"`
+	Ttl      int    `yaml:"ttl"`
+	Data     string `yaml:"content"`
+	Priority int    `yaml:"priority"`
 }
 
 const (
-	TYPE_ALLOWLIST = "A, MX, CNAME, ALIAS, TXT, NS, AAAA, SRV, TLSA, CAA, HTTPS, SVCB"
+	TYPE_ALLOWLIST     = "A, MX, CNAME, ALIAS, TXT, NS, AAAA, SRV, TLSA, CAA, HTTPS, SVCB"
+	PRIORITY_ALLOWLIST = "MX, SRV"
 )
 
 func (r Record) GetName() string {
@@ -31,6 +33,10 @@ func (r Record) GetTtl() string {
 
 func (r Record) GetData() string {
 	return r.Data
+}
+
+func (r Record) GetPriority() string {
+	return fmt.Sprint(r.Priority)
 }
 
 func (r Record) Validate() error {
@@ -53,6 +59,10 @@ func (r Record) Validate() error {
 		return fmt.Errorf("content is required")
 	}
 
+	if r.Priority != 0 && !isPriorityAllowed(r) {
+		return fmt.Errorf("priority must be one of %v", PRIORITY_ALLOWLIST)
+	}
+
 	return nil
 }
 
@@ -63,6 +73,19 @@ func isTypeAllowed(r Record) bool {
 	}
 
 	if _, ok := allowedTypes[r.Type]; !ok {
+		return false
+	}
+
+	return true
+}
+
+func isPriorityAllowed(r Record) bool {
+	allowedPriorities := make(map[string]bool)
+	for _, t := range strings.Split(PRIORITY_ALLOWLIST, ", ") {
+		allowedPriorities[t] = true
+	}
+
+	if _, ok := allowedPriorities[r.Type]; !ok {
 		return false
 	}
 

--- a/pkg/config/record.go
+++ b/pkg/config/record.go
@@ -9,7 +9,7 @@ import (
 const (
 	// Record types that are allowed. Found in Porkbun's API documentation.
 	TYPE_ALLOWLIST = "A, MX, CNAME, ALIAS, TXT, NS, AAAA, SRV, TLSA, CAA, HTTPS, SVCB"
-	// Record types that are allowed to have a priority. Found in Porkbun's API documentation.
+	// Record types that are allowed to have a priority. Found in Porkbun's web app.
 	PRIORITY_ALLOWLIST = "MX, SRV"
 )
 

--- a/pkg/dns/record.go
+++ b/pkg/dns/record.go
@@ -10,6 +10,7 @@ type Record interface {
 	GetType() string
 	GetTtl() string
 	GetData() string
+	GetPriority() string
 }
 
 func RecordEquals(l Record, r Record) bool {
@@ -17,6 +18,7 @@ func RecordEquals(l Record, r Record) bool {
 	equal = equal && l.GetType() == r.GetType()
 	equal = equal && l.GetTtl() == r.GetTtl()
 	equal = equal && l.GetData() == r.GetData()
+	equal = equal && l.GetPriority() == r.GetPriority()
 	return equal
 }
 
@@ -26,5 +28,6 @@ func RecordHash(r Record) string {
 		r.GetType(),
 		r.GetTtl(),
 		r.GetData(),
+		r.GetPriority(),
 	}, "-")
 }

--- a/pkg/providers/porkbun/porkbun.go
+++ b/pkg/providers/porkbun/porkbun.go
@@ -49,6 +49,10 @@ func (p PorkProvider) CreateRecord(domain string, newRecord dns.Record) error {
 		Content: newRecord.GetData(),
 	}
 
+	if newRecord.GetPriority() != "0" {
+		porkRecord.Priority = newRecord.GetPriority()
+	}
+
 	_, err := p.Api.CreateRecord(domain, porkRecord)
 	return err
 }

--- a/pkg/providers/porkbun/record/record.go
+++ b/pkg/providers/porkbun/record/record.go
@@ -28,4 +28,8 @@ func (r Record) GetData() string {
 	return r.Content
 }
 
+func (r Record) GetPriority() string {
+	return r.Priority
+}
+
 var _ dns.Record = Record{}


### PR DESCRIPTION
Enables deployment of MX and SRV records that specify priority.

Closes #52