### PR TITLE
Do not allow records to share host with a CNAME record

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ records:
 - `host` - Required.
 - `content` - Required.
 - `ttl` - Required. Minimum value: `600`.
+- `priority` - Optional. Allowed for `MX` and `SRV` records.
 
 Bacon does not support `priority`. In order to specify a certain `priority`, you must create the record with Bacon and update the `priority` manually.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -11,36 +10,6 @@ import (
 type Config struct {
 	Domain  string   `yaml:"domain"`
 	Records []Record `yaml:"records"`
-}
-
-func (c Config) Validate() error {
-	if c.Domain == "" {
-		return fmt.Errorf("domain is required")
-	}
-
-	for _, record := range c.Records {
-		err := record.Validate()
-		if err != nil {
-			return fmt.Errorf("record is invalid %v: %v", record, err)
-		}
-	}
-
-	cnameHosts := make(map[string]bool)
-	for _, record := range c.Records {
-		if record.GetType() == "CNAME" {
-			if _, ok := cnameHosts[record.GetName()]; ok {
-				return fmt.Errorf("multiple CNAME records for host %s", record.GetName())
-			}
-			cnameHosts[record.GetName()] = true
-		}
-	}
-	for _, record := range c.Records {
-		if record.GetType() != "CNAME" && cnameHosts[record.GetName()] {
-			return fmt.Errorf("non-CNAME record %v shares host with a CNAME record", record)
-		}
-	}
-
-	return nil
 }
 
 func ReadFile(configFile string) (*Config, error) {
@@ -65,7 +34,7 @@ func ReadFile(configFile string) (*Config, error) {
 		return nil, err
 	}
 
-	err = config.Validate()
+	err = ValidateConfiguration(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,21 @@ func (c Config) Validate() error {
 		}
 	}
 
+	cnameHosts := make(map[string]bool)
+	for _, record := range c.Records {
+		if record.GetType() == "CNAME" {
+			if _, ok := cnameHosts[record.GetName()]; ok {
+				return fmt.Errorf("multiple CNAME records for host %s", record.GetName())
+			}
+			cnameHosts[record.GetName()] = true
+		}
+	}
+	for _, record := range c.Records {
+		if record.GetType() != "CNAME" && cnameHosts[record.GetName()] {
+			return fmt.Errorf("non-CNAME record %v shares host with a CNAME record", record)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -165,3 +165,27 @@ records:
 		t.Fatal("priority is not allowed on ALIAS records", err)
 	}
 }
+
+func TestInvalidConfigCnameSameHost(t *testing.T) {
+	configFile, err := SeedConfigToTempFile(`
+domain: bacontest42.com
+records:
+    - host: '*.bacontest42.com'
+      type: CNAME
+      ttl: 600
+      content: pixie.porkbun.com
+    - type: MX
+      host: "*.bacontest42.com"
+      content: in1-smtp.messagingengine.com
+      ttl: 600
+      priority: 10
+`)
+	if err != nil {
+		t.Fatal("could not seed config to temp file", err)
+	}
+
+	_, err = ReadFile(configFile)
+	if err == nil {
+		t.Fatal("cannot have a CNAME and another record for the same host", err)
+	}
+}

--- a/pkg/config/record.go
+++ b/pkg/config/record.go
@@ -3,14 +3,6 @@ package config
 import (
 	"bacon/pkg/dns"
 	"fmt"
-	"strings"
-)
-
-const (
-	// Record types that are allowed. Found in Porkbun's API documentation.
-	TYPE_ALLOWLIST = "A, MX, CNAME, ALIAS, TXT, NS, AAAA, SRV, TLSA, CAA, HTTPS, SVCB"
-	// Record types that are allowed to have a priority. Found in Porkbun's web app.
-	PRIORITY_ALLOWLIST = "MX, SRV"
 )
 
 type Record struct {
@@ -39,59 +31,6 @@ func (r Record) GetData() string {
 
 func (r Record) GetPriority() string {
 	return fmt.Sprint(r.Priority)
-}
-
-func (r Record) Validate() error {
-	if r.Name == "" {
-		return fmt.Errorf("host is required")
-	}
-
-	if r.Type == "" {
-		return fmt.Errorf("type is required")
-	}
-	if !isTypeAllowed(r) {
-		return fmt.Errorf("type must be one of %v", TYPE_ALLOWLIST)
-	}
-
-	if r.Ttl < 600 {
-		return fmt.Errorf("ttl must be at least 600")
-	}
-
-	if r.Data == "" {
-		return fmt.Errorf("content is required")
-	}
-
-	if r.Priority != 0 && !isPriorityAllowed(r) {
-		return fmt.Errorf("priority must be one of %v", PRIORITY_ALLOWLIST)
-	}
-
-	return nil
-}
-
-func isTypeAllowed(r Record) bool {
-	allowedTypes := make(map[string]bool)
-	for _, t := range strings.Split(TYPE_ALLOWLIST, ", ") {
-		allowedTypes[t] = true
-	}
-
-	if _, ok := allowedTypes[r.Type]; !ok {
-		return false
-	}
-
-	return true
-}
-
-func isPriorityAllowed(r Record) bool {
-	allowedPriorities := make(map[string]bool)
-	for _, t := range strings.Split(PRIORITY_ALLOWLIST, ", ") {
-		allowedPriorities[t] = true
-	}
-
-	if _, ok := allowedPriorities[r.Type]; !ok {
-		return false
-	}
-
-	return true
 }
 
 var _ dns.Record = Record{}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"fmt"
+)
+
+var (
+	// Record types that are allowed. Found in Porkbun's API documentation.
+	TYPE_ALLOWLIST = []string{"A", "MX", "CNAME", "ALIAS", "TXT", "NS", "AAAA", "SRV", "TLSA", "CAA", "HTTPS", "SVCB"}
+	// Record types that are allowed to have a priority. Found in Porkbun's web app.
+	PRIORITY_ALLOWLIST = []string{"MX", "SRV"}
+)
+
+func ValidateConfiguration(config Config) error {
+	if config.Domain == "" {
+		return fmt.Errorf("domain is required")
+	}
+
+	for _, record := range config.Records {
+		if err := ValidateRecord(record); err != nil {
+			return fmt.Errorf("%v is invalid: %v", record, err)
+		}
+	}
+
+	if err := configHasUniqueCnameHosts(config.Records); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ValidateRecord(record Record) error {
+	if err := recordHasRequiredFields(record); err != nil {
+		return err
+	}
+
+	if err := recordHasValidType(record); err != nil {
+		return err
+	}
+
+	if err := recordHasValidTtl(record); err != nil {
+		return err
+	}
+
+	if err := recordHasValidPriority(record); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func recordHasRequiredFields(record Record) error {
+	if record.Name == "" {
+		return fmt.Errorf("host is required")
+	}
+
+	if record.Type == "" {
+		return fmt.Errorf("type is required")
+	}
+
+	if record.Data == "" {
+		return fmt.Errorf("content is required")
+	}
+
+	return nil
+}
+
+func recordHasValidType(record Record) error {
+	for _, allowedType := range TYPE_ALLOWLIST {
+		if record.Type == allowedType {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("type must be one of %v", TYPE_ALLOWLIST)
+}
+
+func recordHasValidTtl(record Record) error {
+	if record.Ttl < 600 {
+		return fmt.Errorf("ttl must be at least 600")
+	}
+
+	return nil
+}
+
+func recordHasValidPriority(record Record) error {
+	if record.Priority == 0 {
+		return nil
+	}
+
+	allowedPriorityTypes := make(map[string]bool)
+	for _, t := range PRIORITY_ALLOWLIST {
+		allowedPriorityTypes[t] = true
+	}
+
+	if _, ok := allowedPriorityTypes[record.Type]; !ok {
+		return fmt.Errorf("type must be one of %v to have priority", PRIORITY_ALLOWLIST)
+	}
+
+	return nil
+}
+
+func configHasUniqueCnameHosts(records []Record) error {
+	cnameHosts := make(map[string]bool)
+	for _, record := range records {
+		if record.Type == "CNAME" {
+			if _, ok := cnameHosts[record.Name]; ok {
+				return fmt.Errorf("multiple CNAME records exist for host %s", record.Name)
+			}
+			cnameHosts[record.Name] = true
+		}
+	}
+
+	for _, record := range records {
+		if record.Type == "CNAME" {
+			continue
+		}
+		if cnameHosts[record.Name] {
+			return fmt.Errorf("non-CNAME record %v shares host with a CNAME record", record)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes a tiny bug. Porkbun does not allow non-CNAME records to share a host with a CNAME record.

Closes #38 